### PR TITLE
profiles: bootstrap Hyprland config files from config_files

### DIFF
--- a/core/shells/bash/profiles/.config_files
+++ b/core/shells/bash/profiles/.config_files
@@ -48,3 +48,16 @@ else
         fi
     done <<< "$firefox_profiles"
 fi
+
+if command -v Hyprland &> /dev/null || [ -d "$HOME/.config/hypr" ]; then
+    mkdir -p "$HOME/.config/hypr/wallpaper"
+
+    if [ ! -f "$HOME/.config/hypr/hyprland.conf" ]; then
+        curl -o "$HOME/.config/hypr/hyprland.conf" https://raw.githubusercontent.com/e-lemongrab/config_files/refs/heads/master/hyprland/hyprland.conf > /dev/null 2>&1
+    fi
+
+    if [ ! -f "$HOME/.config/hypr/wallpaper/wallpaper-rotation.sh" ]; then
+        curl -o "$HOME/.config/hypr/wallpaper/wallpaper-rotation.sh" https://raw.githubusercontent.com/e-lemongrab/config_files/refs/heads/master/hyprland/wallpaper/wallpaper-rotation.sh > /dev/null 2>&1
+        chmod +x "$HOME/.config/hypr/wallpaper/wallpaper-rotation.sh"
+    fi
+fi


### PR DESCRIPTION
## Summary
- extend the `config_files` profile so it can also bootstrap Hyprland config from `config_files`
- create the expected Hyprland directory structure under `~/.config/hypr`
- install the wallpaper rotation script with executable permissions

## Changes
- `core/shells/bash/profiles/.config_files`
  - if `Hyprland` is installed or `~/.config/hypr` already exists:
    - create `~/.config/hypr/wallpaper`
    - download `hyprland/hyprland.conf` if missing
    - download `hyprland/wallpaper/wallpaper-rotation.sh` if missing
    - mark `wallpaper-rotation.sh` as executable

## Notes
- this PR still leaves `nvidiafan.sh` as an optional local script outside the repo
- behavior stays consistent with the rest of the profile: only bootstrap missing files, do not overwrite existing user-managed config