### PR TITLE
services: bootstrap NVIDIA fan user service from config_files

### DIFF
--- a/core/shells/bash/.bashrc
+++ b/core/shells/bash/.bashrc
@@ -69,6 +69,9 @@ fi
 if [ -f "$project_path"/core/shells/bash/services/.hyprland-wallpaper ]; then
 	. "$project_path"/core/shells/bash/services/.hyprland-wallpaper
 fi
+if [ -f "$project_path"/core/shells/bash/services/.nvidia-fan ]; then
+	. "$project_path"/core/shells/bash/services/.nvidia-fan
+fi
 # Bash time lapse ends
 final_result=$(date +%s%3N)
 elapsed_time=$((final_result - initial_result))

--- a/core/shells/bash/services/.nvidia-fan
+++ b/core/shells/bash/services/.nvidia-fan
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if ! command -v systemctl >/dev/null 2>&1; then
+    return 0 2>/dev/null || exit 0
+fi
+
+SCRIPT_FILE="$HOME/Documents/doc/z_linux/nvidia/nvidiafan.sh"
+
+if [ ! -f "$SCRIPT_FILE" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+SERVICE_DIR="$HOME/.config/systemd/user"
+SERVICE_FILE="$SERVICE_DIR/nvidia-fan.service"
+SERVICE_URL="https://raw.githubusercontent.com/e-lemongrab/config_files/refs/heads/master/services/nvidia/nvidia-fan.service"
+
+changed=0
+
+mkdir -p "$SERVICE_DIR"
+
+if [ ! -f "$SERVICE_FILE" ]; then
+    curl -o "$SERVICE_FILE" "$SERVICE_URL" > /dev/null 2>&1 && changed=1
+fi
+
+if ! systemctl --user is-enabled nvidia-fan.service >/dev/null 2>&1; then
+    changed=1
+fi
+
+if [ "$changed" -eq 1 ]; then
+    systemctl --user daemon-reload >/dev/null 2>&1
+    systemctl --user enable --now nvidia-fan.service >/dev/null 2>&1
+fi


### PR DESCRIPTION
## Summary
- add NVIDIA fan control to the bash `services` loading block
- bootstrap the `nvidia-fan.service` user service from `config_files`
- only activate it when the local NVIDIA fan script already exists

## Changes
- `core/shells/bash/.bashrc`
  - load `core/shells/bash/services/.nvidia-fan` if present
- `core/shells/bash/services/.nvidia-fan`
  - if `systemctl` is available and the local script exists at `$HOME/Documents/doc/z_linux/nvidia/nvidiafan.sh`:
    - ensure `~/.config/systemd/user/` exists
    - download `nvidia-fan.service` from `config_files` if missing
    - run `systemctl --user daemon-reload`
    - run `systemctl --user enable --now nvidia-fan.service` when needed

## Notes
- this follows the same activation pattern used for `services/.hyprland-wallpaper`
- unlike wallpaper rotation, the script itself is not downloaded because it is still treated as external/local
- if the local script does not exist, this loader exits without changing anything