### PR TITLE
docs: document bash services block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Framework for bash
 - [How to use](#how-to-use)
   - [Bash](#bash)
   - [Powershell](#powershell)
+- [Profiles and services](#profiles-and-services)
 
 ## Project details:
 
@@ -34,6 +35,7 @@ You will use .bash_profile file (section 'how to use') to load this project and 
     - functions
     - jobs
     - profiles
+    - services
     - .bash_profile
     - .bashrc
   - pwsh: Containing pwsh environment (will be deprecated soon)
@@ -71,7 +73,6 @@ exec -l $SHELL
 
 3. Run "checks" to list compatibility and "myshell" to get the available commands to use
 
-
 ### Powershell:
 
 Once done the bash configuration, if you have "pwsh" installed, automatically will set the $PROFILE for powershell - $HOME/.config/powershell/Microsoft.PowerShell_profile.ps1
@@ -84,3 +85,49 @@ If you want to use this profile from Windows:
 Remember to set the value for section "VARIABLE DECLARATION":
 - $global:distro=xxx
 - $global:project_path=xxx (relative path from $HOME)
+
+## Profiles and services
+
+`myshell` loads optional bash components from `core/shells/bash/profiles/` and `core/shells/bash/services/` through explicit blocks in `core/shells/bash/.bashrc`.
+
+### Profiles
+
+Profiles are sourced from `core/shells/bash/profiles/` and are used for shell environment setup and bootstrap behavior.
+
+Examples currently loaded from `.bashrc` include:
+- `.git-configs`
+- `.appearance`
+- `.completion`
+- `.history`
+- `.path`
+- `.pwsh`
+- `.software`
+- `.config_files`
+- `.ssh`
+
+### Services
+
+Services are sourced from `core/shells/bash/services/` and are used to bootstrap user services or other service-like integrations that should not live in normal shell profiles.
+
+Current examples include:
+- `.hyprland-wallpaper`
+- `.nvidia-fan`
+
+These files are sourced from `.bashrc`, so their activation is reflected there and can be controlled by adding, removing, or commenting the corresponding loader block.
+
+### Current behavior
+
+- `.hyprland-wallpaper`
+  - downloads `hypr-wallpaper.service` from `config_files`
+  - downloads `wallpaper-rotation.sh` from `config_files`
+  - installs them into local user paths
+  - runs `systemctl --user daemon-reload`
+  - runs `systemctl --user enable --now hypr-wallpaper.service` when needed
+
+- `.nvidia-fan`
+  - downloads `nvidia-fan.service` from `config_files`
+  - only acts if the local script already exists at `$HOME/Documents/doc/z_linux/nvidia/nvidiafan.sh`
+  - runs `systemctl --user daemon-reload`
+  - runs `systemctl --user enable --now nvidia-fan.service` when needed
+
+The service definitions come from `config_files`, while `myshell` acts as the bootstrap / installer side.


### PR DESCRIPTION
## Summary
- document the new bash `services` block in the README
- explain how `profiles` and `services` are loaded from `.bashrc`
- document the current service loaders and what they do

## Changes
- add a new `Profiles and services` section to `README.md`
- document the `core/shells/bash/services/` directory as a separate concept from `profiles`
- list the current service loaders:
  - `.hyprland-wallpaper`
  - `.nvidia-fan`
- explain the current behavior of both service loaders and their relation to `config_files`

## Notes
- this is a documentation-only PR
- no behavior changes are included here