### PR TITLE
services: download nvidia fan script from config_files

### DIFF
--- a/core/shells/bash/services/.nvidia-fan
+++ b/core/shells/bash/services/.nvidia-fan
@@ -4,22 +4,33 @@ if ! command -v systemctl >/dev/null 2>&1; then
     return 0 2>/dev/null || exit 0
 fi
 
-SCRIPT_FILE="$HOME/Documents/doc/z_linux/nvidia/nvidiafan.sh"
-
-if [ ! -f "$SCRIPT_FILE" ]; then
-    return 0 2>/dev/null || exit 0
-fi
-
 SERVICE_DIR="$HOME/.config/systemd/user"
 SERVICE_FILE="$SERVICE_DIR/nvidia-fan.service"
+SCRIPT_DIR="$HOME/.config/nvidia"
+SCRIPT_FILE="$SCRIPT_DIR/nvidiafan.sh"
+
 SERVICE_URL="https://raw.githubusercontent.com/e-lemongrab/config_files/refs/heads/master/services/nvidia/nvidia-fan.service"
+SCRIPT_URL="https://raw.githubusercontent.com/e-lemongrab/config_files/refs/heads/master/services/nvidia/nvidiafan.sh"
 
 changed=0
 
 mkdir -p "$SERVICE_DIR"
+mkdir -p "$SCRIPT_DIR"
 
 if [ ! -f "$SERVICE_FILE" ]; then
     curl -o "$SERVICE_FILE" "$SERVICE_URL" > /dev/null 2>&1 && changed=1
+fi
+
+if [ ! -f "$SCRIPT_FILE" ]; then
+    curl -o "$SCRIPT_FILE" "$SCRIPT_URL" > /dev/null 2>&1 && changed=1
+fi
+
+if [ -f "$SCRIPT_FILE" ]; then
+    chmod +x "$SCRIPT_FILE"
+fi
+
+if [ ! -f "$SCRIPT_FILE" ]; then
+    return 0 2>/dev/null || exit 0
 fi
 
 if ! systemctl --user is-enabled nvidia-fan.service >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- update `.nvidia-fan` so it downloads the NVIDIA fan script from `config_files`
- align NVIDIA fan management with the same model used for the wallpaper rotation script
- install the script into a final local path under `~/.config/nvidia/`

## Changes
- `core/shells/bash/services/.nvidia-fan`
  - ensure `~/.config/nvidia/` exists
  - download `services/nvidia/nvidiafan.sh` from `config_files` if missing
  - mark the script executable
  - keep downloading `nvidia-fan.service` if missing
  - continue to run `systemctl --user daemon-reload` and `systemctl --user enable --now nvidia-fan.service` when needed

## Notes
- this change assumes the matching `config_files` PR is merged so the script exists in `services/nvidia/nvidiafan.sh`
- README/docs can be updated separately if you want to keep this PR purely operational