### PR TITLE
profiles: support absolute Firefox profile paths

### DIFF
--- a/core/shells/bash/profiles/.config_files
+++ b/core/shells/bash/profiles/.config_files
@@ -10,7 +10,11 @@ else
     firefox_profiles=$(awk -F'=' '/^Path=/{print $2}' ~/.mozilla/firefox/profiles.ini)
 
     while IFS= read -r profile; do
-        profile_dir="$HOME/.mozilla/firefox/$profile"
+        if [[ "$profile" = /* ]]; then
+            profile_dir="$profile"
+        else
+            profile_dir="$HOME/.mozilla/firefox/$profile"
+        fi
 
         if [[ "$profile_dir" == *"/work/"* ]]; then
             echo "Skipping profile in work directory: $profile_dir"


### PR DESCRIPTION
## Summary
- fix Firefox profile handling in `profiles/.config_files` for absolute `Path=` entries
- keep overwrite behavior for managed `user.js`
- preserve the existing skip for `work` profiles

## Changes
- `core/shells/bash/profiles/.config_files`
  - when a Firefox profile path starts with `/`, treat it as an absolute path
  - otherwise keep the existing relative-path behavior under `~/.mozilla/firefox/`
  - continue skipping profiles whose resolved path contains `/work/`
  - continue overwriting `user.js` in the remaining managed profiles

## Why
The current overwrite logic assumes every `Path=` in `profiles.ini` is relative. That breaks setups using `IsRelative=0`, such as profiles stored under `/data/firefox-profile/...`, so `user.js` updates never reach the real active profile.

## Notes
- this is a targeted fix for path resolution only
- it is meant to work together with the recent overwrite behavior added to `profiles/.config_files`