### PR TITLE
docs: rewrite README around framework identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,100 +1,178 @@
 # myshell
 
-Framework for bash
+`myshell` is a Bash-first hybrid framework for building, bootstrapping, and operating a modular user environment.
 
-- [Project details](#project-details)
-  - [Core](#core)
-  - [Modules](#modules)
-    - [Help](#help)
-    - [cloud](#cloud)
-    - [Docker](#docker)
-    - [k8s](#k8s)
-    - [ssh](#ssh)
-    - [bw](#bw)
-    - [John](#john)
-    - [Utils](#utils)
-- [Requirements](#requirements)
-- [How to use](#how-to-use)
-  - [Bash](#bash)
-  - [Powershell](#powershell)
-- [Profiles and services](#profiles-and-services)
+It treats the shell runtime as the technical base, then layers optional profiles, user services, and operational modules on top of it. The result is a structured system that aims for two main properties:
 
-## Project details:
+- **modularity**: each component has a clear layer, a concrete purpose, and explicit activation
+- **reproducibility**: the managed local environment and its modular composition can be reproduced consistently
 
-You will use .bash_profile file (section 'how to use') to load this project and the two main sections:
-- Core: Files for managing shell profile
-- Modules: Section for tools
+`myshell` is not intended to look like a classic dotfiles repository, a loose collection of personal scripts, a simple `.bashrc` bootstrap, or a package manager. It is meant to behave like a lightweight, Bash-based framework for managing a stable user environment and exposing reusable operational tooling.
+
+## Scope
+
+`myshell` is designed to:
+- bootstrap a Bash-based user environment
+- manage shell runtime behavior through a structured core
+- load optional profiles and user services explicitly
+- expose operational modules through a stable framework structure
+- integrate official external companion repositories such as `config_files`
+
+`myshell` is **not** designed to:
+- manage arbitrary local state outside its declared managed components
+- behave like a package manager
+- present itself as a generic framework without a concrete user-environment use case
+
+## Core model
+
+`myshell` is organized around the following layers:
 
 ### Core
+The core is the runtime base of the framework. It provides the shell entrypoints and the structure through which the rest of the system is loaded.
 
-- Scripts folder:
-  - Random password generator (handled by powershell, will be replaced by another language soon)
-- Shells folder:
-  - bash: 
-    - aliases
-    - functions
-    - jobs
-    - profiles
-    - services
-    - .bash_profile
-    - .bashrc
-  - pwsh: Containing pwsh environment (will be deprecated soon)
+This includes:
+- `.bash_profile`
+- `.bashrc`
+- aliases
+- functions
+- jobs
+
+### Profiles
+Profiles are optional environment components loaded from `core/shells/bash/profiles/`.
+
+Profiles are part of the framework core model. They are used for shell environment setup, bootstrap behavior, and managed configuration deployment.
+
+Profiles are opt-in through explicit loader blocks in `.bashrc`.
+
+### Services
+Services are optional components loaded from `core/shells/bash/services/`.
+
+Services are also part of the framework core model, but are intended for persistent or service-like integrations that should not live as normal shell profiles.
+
+Typical examples are `systemd --user` units and their companion scripts.
+
+Services are opt-in through explicit loader blocks in `.bashrc`.
 
 ### Modules
+Modules are operational tooling components. They expose commands and workflows on top of the stable user-environment base provided by the framework.
 
-- #### Help
-- #### cloud
-- #### Docker
-- #### k8s
-- #### ssh
-- #### bw
-- #### John
-- #### Utils
+Modules are part of the core identity of `myshell`, not an afterthought.
 
-## Requirements
+### Optional components
+PowerShell support exists as an optional layer. It is supported, but it is not part of the primary identity of the framework.
 
-- Basic packages ```` git file curl ````
+### Official external companion repositories
+`myshell` supports official companion repositories that are external in storage but functionally part of the framework ecosystem.
 
-Mainly tested on bash 5.2+.
+The primary companion repository is:
+- `config_files`
 
-## How to use
+`config_files` is not treated as a secondary integration. It is the official companion repository for managed external configuration consumed by `myshell`.
 
-### Bash:
+## Managed vs unmanaged behavior
 
-1. Backup your $HOME/.bash_profile if exists
-2. Clone where you want, copy .bash_profile to your home and set $project_path. Then restart the current shell session.
+A core principle of `myshell` is explicit control.
 
-````
+When a component is active and managed by the framework, the framework is authoritative for that component.
+
+When a component is disabled, it stops being managed.
+
+This means:
+- active managed components are expected to follow framework-defined behavior
+- disabled components are outside the authority of the framework
+- activation state is explicit and visible through the corresponding loader blocks
+
+## Stability model
+
+`myshell` aims to keep both of these stable:
+- the **structure** of the framework
+- the **experience of use**
+
+What may vary:
+- which profiles, services, and modules are enabled
+- which components are sourced from the official companion repository
+- future official external integrations in the `myshell` ecosystem
+
+## Activation model
+
+The framework is designed around explicit, visible activation.
+
+The expected user experience is:
+- load a predefined environment
+- enable or disable explicit pieces of that environment
+- use operational modules on top of a stable base
+
+This is an opt-in modular system, not a hidden auto-magic bootstrap.
+
+## Why Bash-first matters
+
+`myshell` is Bash-first by design.
+
+Bash is not just the implementation language; it is part of the framework identity. The framework is intended to stay technically direct, operational, and readable while still being powerful.
+
+The target is **power within visible simplicity**:
+- the internal system can grow
+- but the user model and framework structure should remain understandable and explicit
+
+## Repository structure
+
+Current top-level structure relevant to the framework model:
+
+- `core/`
+  - framework runtime and shell entrypoints
+- `core/shells/bash/profiles/`
+  - optional managed environment components
+- `core/shells/bash/services/`
+  - optional managed service integrations
+- `core/shells/bash/.bash_profile`
+  - framework entrypoint
+- `core/shells/bash/.bashrc`
+  - explicit activation surface for profiles and services
+- `modules/`
+  - operational toolkit components
+- `core/shells/pwsh/`
+  - optional PowerShell support
+
+## Installation
+
+### Bash
+
+1. Back up your current `$HOME/.bash_profile` if needed.
+2. Clone the repository.
+3. Copy the framework entrypoint to your home.
+4. Set `project_path`.
+5. Reload the shell session.
+
+```bash
 git clone git@github.com:e-lemongrab/myshell.git
-cp -rfv myshell/core/shells/bash/.bash_profile $HOME
-sed -i 's|$HOME/Documents/myshell|'"$(pwd)"'/myshell|g' ~/.bash_profile
-exec -l $SHELL
-````
+cp -rfv myshell/core/shells/bash/.bash_profile "$HOME"
+sed -i 's|$HOME/Documents/myshell|'"$(pwd)"'/myshell|g' "$HOME/.bash_profile"
+exec -l "$SHELL"
+```
 
-3. Run "checks" to list compatibility and "myshell" to get the available commands to use
+After that:
+- run `checks` to list compatibility information
+- run `myshell` to view available commands
 
-### Powershell:
+### PowerShell
 
-Once done the bash configuration, if you have "pwsh" installed, automatically will set the $PROFILE for powershell - $HOME/.config/powershell/Microsoft.PowerShell_profile.ps1
+Once the Bash configuration is active, and if `pwsh` is installed, `myshell` can also set the PowerShell profile at:
 
-If you want to use this profile from Windows:
+- `~/.config/powershell/Microsoft.PowerShell_profile.ps1`
 
-1. Install WSL2 distro
-2. Edit $PROFILE (ex: code $PROFILE, from a powershell terminal) with content from content core/shells/pwsh/Microsoft.PowerShell_profile.ps1
+If you want to use the PowerShell profile from Windows:
 
-Remember to set the value for section "VARIABLE DECLARATION":
-- $global:distro=xxx
-- $global:project_path=xxx (relative path from $HOME)
+1. Install a WSL2 distribution.
+2. Edit `$PROFILE` with the content from `core/shells/pwsh/Microsoft.PowerShell_profile.ps1`.
+3. Set the required values in the `VARIABLE DECLARATION` section.
 
 ## Profiles and services
 
-`myshell` loads optional bash components from `core/shells/bash/profiles/` and `core/shells/bash/services/` through explicit blocks in `core/shells/bash/.bashrc`.
+`myshell` loads optional Bash components from `core/shells/bash/profiles/` and `core/shells/bash/services/` through explicit blocks in `core/shells/bash/.bashrc`.
 
-### Profiles
+### Profiles currently loaded by default blocks in `.bashrc`
 
-Profiles are sourced from `core/shells/bash/profiles/` and are used for shell environment setup and bootstrap behavior.
-
-Examples currently loaded from `.bashrc` include:
+Examples include:
 - `.git-configs`
 - `.appearance`
 - `.completion`
@@ -105,48 +183,77 @@ Examples currently loaded from `.bashrc` include:
 - `.config_files`
 - `.ssh`
 
-### Services
+### Services currently supported
 
-Services are sourced from `core/shells/bash/services/` and are used to bootstrap user services or other service-like integrations that should not live in normal shell profiles.
-
-Current examples include:
+Examples include:
 - `.hyprland-wallpaper`
 - `.nvidia-fan`
 
-These files are sourced from `.bashrc`, so their activation is reflected there and can be controlled by adding, removing, or commenting the corresponding loader block.
+These are framework-managed service integrations and are activated through `.bashrc` loader blocks.
 
-### Current behavior
+### Current service behavior
 
-- `.hyprland-wallpaper`
-  - downloads `hypr-wallpaper.service` from `config_files`
-  - downloads `wallpaper-rotation.sh` from `config_files`
-  - installs them into local user paths
-  - runs `systemctl --user daemon-reload`
-  - runs `systemctl --user enable --now hypr-wallpaper.service` when needed
+`.hyprland-wallpaper`
+- downloads `hypr-wallpaper.service` from `config_files`
+- downloads `wallpaper-rotation.sh` from `config_files`
+- installs them into local user paths
+- runs `systemctl --user daemon-reload`
+- runs `systemctl --user enable --now hypr-wallpaper.service` when needed
 
-- `.nvidia-fan`
-  - downloads `nvidia-fan.service` from `config_files`
-  - only acts if the local script already exists at `$HOME/Documents/doc/z_linux/nvidia/nvidiafan.sh`
-  - runs `systemctl --user daemon-reload`
-  - runs `systemctl --user enable --now nvidia-fan.service` when needed
+`.nvidia-fan`
+- downloads `nvidia-fan.service` from `config_files`
+- downloads `nvidiafan.sh` from `config_files`
+- installs them into local user paths
+- runs `systemctl --user daemon-reload`
+- runs `systemctl --user enable --now nvidia-fan.service` when needed
 
 ### Service prerequisites
 
-- `.hyprland-wallpaper`
-  - `hyprpaper`
-  - `hyprctl`
-  - a valid `~/.config/hypr/hyprpaper.conf`
-  - a local wallpaper directory configured in the script through `WALLPAPER_DIR`
-  - `mpvpaper` if video wallpapers are used
-  - monitor names and interval may need local adjustment
+`.hyprland-wallpaper`
+- `hyprpaper`
+- `hyprctl`
+- a valid `~/.config/hypr/hyprpaper.conf`
+- a local wallpaper directory configured in the script through `WALLPAPER_DIR`
+- `mpvpaper` if video wallpapers are used
+- monitor names and interval may need local adjustment
 
-- `.nvidia-fan`
-  - `nvidia-smi`
-  - `nvidia-settings`
-  - `sudo`
-  - `xhost`
-  - a local script at `$HOME/Documents/doc/z_linux/nvidia/nvidiafan.sh`
-  - `sudo` for `nvidia-settings` must work non-interactively in the session where the service runs
-  - the graphical session must be ready; the service definition uses a short startup delay to avoid login-time race conditions
+`.nvidia-fan`
+- `nvidia-smi`
+- `nvidia-settings`
+- `sudo`
+- `xhost`
+- a deployed script at `~/.config/nvidia/nvidiafan.sh`
+- `sudo` for `nvidia-settings` must work non-interactively in the session where the service runs
+- the graphical session must be ready; the service definition uses a short startup delay to avoid login-time race conditions
 
-The service definitions come from `config_files`, while `myshell` acts as the bootstrap / installer side.
+## Companion repository: `config_files`
+
+`config_files` is the official companion repository of `myshell`.
+
+Within the framework model:
+- `myshell` is the framework and orchestration layer
+- `config_files` is the managed external source of truth for supported configuration artifacts
+
+This relationship is part of the intended architecture of the framework.
+
+## Extension model
+
+`myshell` is modular, but that modularity is structured.
+
+In practice, new functionality should fit one of the framework layers:
+- core runtime behavior
+- profile
+- service
+- module
+- official external companion integration
+
+If a new component does not clearly fit one of those layers, it should not be added until its role is defined.
+
+## Summary
+
+`myshell` should be understood as:
+- a Bash-first hybrid framework
+- a structured user-environment manager
+- a modular shell and services system
+- a reproducible local environment framework
+- a lightweight operational platform built on top of Bash


### PR DESCRIPTION
## Summary
- rewrite the README in English around the intended identity of `myshell`
- present `myshell` as a Bash-first hybrid framework instead of a generic shell repo
- make the framework model, scope, control model, and companion-repo relationship explicit

## Changes
- `README.md`
  - replace the previous repo overview with a framework-oriented description
  - define the scope and intended identity of `myshell`
  - document the core model: core, profiles, services, modules, optional PowerShell, official external companion repositories
  - describe managed vs unmanaged behavior
  - describe the stability and activation models
  - document the Bash-first identity and the companion role of `config_files`
  - keep installation and current behavior sections, but framed within the framework model

## Why
The previous README explained the repository structure, but it did not fully present `myshell` as a closed-identity framework with a clear conceptual model. This rewrite is intended to align the documentation with the role `myshell` is meant to have: a structured, modular, reproducible, Bash-first framework for managing a user environment and exposing operational tooling.

## Notes
- this PR is focused on identity and documentation
- it does not change runtime behavior