### PR TITLE
hyprland: migrate myshell wallpaper helper to native hyprpaper

### DIFF
--- a/core/shells/bash/services/.hyprland-wallpaper
+++ b/core/shells/bash/services/.hyprland-wallpaper
@@ -9,35 +9,42 @@ if ! command -v Hyprland >/dev/null 2>&1 && [ ! -d "$HOME/.config/hypr" ]; then
 fi
 
 SERVICE_DIR="$HOME/.config/systemd/user"
-SERVICE_FILE="$SERVICE_DIR/hypr-wallpaper.service"
+LEGACY_SERVICE_FILE="$SERVICE_DIR/hypr-wallpaper.service"
 SCRIPT_DIR="$HOME/.config/hypr"
-SCRIPT_FILE="$SCRIPT_DIR/wallpaper-rotation.sh"
-
-SERVICE_URL="https://raw.githubusercontent.com/e-lemongrab/config_files/refs/heads/master/services/hyprland/hypr-wallpaper.service"
-SCRIPT_URL="https://raw.githubusercontent.com/e-lemongrab/config_files/refs/heads/master/services/hyprland/wallpaper-rotation.sh"
+LEGACY_SCRIPT_FILE="$SCRIPT_DIR/wallpaper-rotation.sh"
+HYPRPAPER_CONFIG_FILE="$SCRIPT_DIR/hyprpaper.conf"
+HYPRPAPER_CONFIG_URL="https://raw.githubusercontent.com/e-lemongrab/config_files/refs/heads/master/hyprland/hyprpaper.conf"
 
 changed=0
 
 mkdir -p "$SERVICE_DIR"
 mkdir -p "$SCRIPT_DIR"
 
-if [ ! -f "$SERVICE_FILE" ]; then
-    curl -o "$SERVICE_FILE" "$SERVICE_URL" > /dev/null 2>&1 && changed=1
+if ! curl -fsSL -o "$HYPRPAPER_CONFIG_FILE" "$HYPRPAPER_CONFIG_URL" >/dev/null 2>&1; then
+    return 0 2>/dev/null || exit 0
+fi
+changed=1
+
+if systemctl --user is-enabled hypr-wallpaper.service >/dev/null 2>&1; then
+    systemctl --user disable --now hypr-wallpaper.service >/dev/null 2>&1 || true
+    changed=1
 fi
 
-if [ ! -f "$SCRIPT_FILE" ]; then
-    curl -o "$SCRIPT_FILE" "$SCRIPT_URL" > /dev/null 2>&1 && changed=1
+if [ -f "$LEGACY_SERVICE_FILE" ]; then
+    rm -f "$LEGACY_SERVICE_FILE"
+    changed=1
 fi
 
-if [ -f "$SCRIPT_FILE" ]; then
-    chmod +x "$SCRIPT_FILE"
+if [ -f "$LEGACY_SCRIPT_FILE" ]; then
+    rm -f "$LEGACY_SCRIPT_FILE"
+    changed=1
 fi
 
-if ! systemctl --user is-enabled hypr-wallpaper.service >/dev/null 2>&1; then
+if ! systemctl --user is-enabled hyprpaper.service >/dev/null 2>&1; then
     changed=1
 fi
 
 if [ "$changed" -eq 1 ]; then
     systemctl --user daemon-reload >/dev/null 2>&1
-    systemctl --user enable --now hypr-wallpaper.service >/dev/null 2>&1
+    systemctl --user enable --now hyprpaper.service >/dev/null 2>&1
 fi


### PR DESCRIPTION
## Summary
- stop deploying the legacy `hypr-wallpaper.service` and `wallpaper-rotation.sh`
- fetch `hyprpaper.conf` from `config_files`
- disable and remove the legacy wallpaper service artifacts locally
- enable `hyprpaper.service` instead

## Why
`config_files` now moves wallpaper handling to native `hyprpaper` configuration and removes the custom rotation service. `myshell` still deployed the old service/script pair, so it needed to be aligned to avoid reinstalling the deprecated path after shell startup.

## Notes
- this helper now behaves as a migration path for existing local installs
- it intentionally keeps using the current `config_files` branch head as source of truth for `hyprpaper.conf`
- the wallpaper path inside `hyprpaper.conf` remains machine-specific and should still be treated as local runtime config if needed later
