### PR TITLE
Restore OS name in shell prompt

### DIFF
--- a/core/shells/bash/profiles/.appearance
+++ b/core/shells/bash/profiles/.appearance
@@ -58,7 +58,14 @@ unset aws_cache_root aws_cache_key aws_cache_file aws_cache_tmp identity_arn ide
 
 ## Color and appearance
 # PS1 - prompt
-OS_RELEASE=$(sed -n 's/^PRETTY_NAME="\\(.*\\)"/\\1/p' /etc/os-release)
+OS_RELEASE=$(
+	if [ -r /etc/os-release ]; then
+		. /etc/os-release
+		printf '%s' "${PRETTY_NAME:-${NAME:-}}"
+	else
+		uname -s
+	fi
+)
 color_prompt=yes
 if [ "$color_prompt" = yes ]; then
     PS1='\n\[\033[01;40m\]┌──${debian_chroot:+($debian_chroot)}\[\033[01;33m\]\u@\h:\w$\[\033[01;40m\]\[\033[01;91m\]$(parse_git_branch)\[\033[00m\]\n\[\033[01;40m\]│\[\033[00m\] $(date +%H:%M:%S) | Jobs: \j | $OS_RELEASE | $(basename $SHELL) \V \

--- a/tests/validate.bash
+++ b/tests/validate.bash
@@ -157,6 +157,16 @@ grep -q '^while true; do$' core/shells/bash/jobs/public_ip.bash ||
 if grep -q 'disown' core/shells/bash/.bashrc; then
 	fail "persistent shell job is removed from the job table"
 fi
+expected_os=$(
+	. /etc/os-release
+	printf '%s' "${PRETTY_NAME:-${NAME:-}}"
+)
+actual_os=$(AWS_PROFILE= bash --noprofile --norc -c '
+	. core/shells/bash/profiles/.appearance
+	printf "%s" "$OS_RELEASE"
+')
+[ "$actual_os" = "$expected_os" ] ||
+	fail "prompt OS name does not match /etc/os-release PRETTY_NAME"
 printf '[6/10] framework smoke tests (%d module commands)\n' "$command_count"
 
 # 7. Validate YAML and every Compose model without starting containers.


### PR DESCRIPTION
## Qué cambia

- Restaura `PRETTY_NAME` desde `/etc/os-release` en el prompt.
- Usa `uname -s` como fallback cuando `os-release` no está disponible.
- Añade una prueba de regresión que compara el valor mostrado con el sistema.

## Causa raíz

La expresión `sed` contenía barras invertidas duplicadas y devolvía una cadena vacía.

## Impacto

El prompt vuelve a mostrar el nombre del sistema operativo, por ejemplo `Arch Linux`.

## Validación

- `bash tests/validate.bash` — 10/10, `VALIDATION PASSED`.
- Comprobación directa: `OS_RELEASE=Arch Linux`.