### PR TITLE
Pin third-party actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  # The actions are pinned to commit SHAs so a moved tag cannot change what CI
+  # runs. That only stays safe if something keeps them current, otherwise the
+  # pins rot into unpatched versions — which is worse than not pinning.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/tests/validate.bash
+++ b/tests/validate.bash
@@ -260,15 +260,19 @@ while IFS= read -r dockerfile; do
 done < <(find modules/docker -type f -name Dockerfile | sort)
 printf '[8/10] Docker structure and versioning\n'
 
-# 9. CI actions are immutable and the duplicated manual workflow stays removed.
-[ ! -e .github/workflows/manual.yml ] || fail "manual.yml duplicates workflow_dispatch in schedule.yml"
+# 9. CI actions are immutable and every workflow declares its permissions.
+[ ! -e .github/workflows/manual.yml ] || fail "manual.yml duplicates an existing workflow_dispatch"
 while IFS= read -r action_reference; do
 	action_value=${action_reference##*@}
 	[[ "$action_value" =~ ^[0-9a-f]{40}([[:space:]]*#.*)?$ ]] ||
 		fail "GitHub Action is not pinned to a commit: $action_reference"
 done < <(sed -nE 's/^[[:space:]]*uses:[[:space:]]*//p' .github/workflows/*.yml)
-grep -q '^permissions:' .github/workflows/schedule.yml || fail "publish workflow permissions missing"
-grep -q '^permissions:' .github/workflows/validate.yml || fail "validation workflow permissions missing"
+# Checked per workflow present rather than by name: the previous version named
+# schedule.yml explicitly, so removing that workflow left the gate failing on a
+# file it no longer expected to exist.
+while IFS= read -r workflow; do
+	grep -q '^permissions:' "$workflow" || fail "workflow permissions missing: $workflow"
+done < <(find .github/workflows -maxdepth 1 -name '*.yml' | sort)
 printf '[9/10] CI policy\n'
 
 # 10. Core portability rules and an informational personal-config inventory.


### PR DESCRIPTION
An action tag is mutable. Whoever controls that repository can move `v4` to point at
different code, and it runs **inside our job**, with whatever that job holds.

For the deploy jobs here that means `KUBECONFIG_B64`, `GHCR_PAT` and the Bitwarden
token — and those jobs run on self-hosted runners **inside the cluster itself**, so a
compromised action is not contained the way it would be on a GitHub-hosted runner.

This is not hypothetical: in March 2025 `tj-actions/changed-files` was compromised by
moving its tags to a commit that dumped CI secrets into the logs, across thousands of
repositories. Repos pinned by SHA were unaffected, because their reference still
pointed at the commit they had always used.

## What changes

Every third-party action is pinned to the commit SHA its tag pointed at, with the tag
kept in a trailing comment so the file stays readable:

```yaml
uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
```

## Why dependabot.yml is in the same commit

A SHA does not receive security fixes on its own. Pinning without something to keep
the pins current turns them into unpatched versions, which is worse than not pinning.
Dependabot understands SHA-pinned actions, bumps them, and maintains the version
comment.

## What is deliberately not pinned

`e-lemongrab/arc-system/.github/actions/verify-deployed-image@master` stays on a
branch. Pinning it would mean editing every reference for each change to our own
shared action, and the risk pinning addresses is a third party being compromised, not
ourselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)